### PR TITLE
Rebase vagrant box to xenial64 w/ python3.6 venv

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ end
 
 Vagrant.configure("2") do |config|
   config.vm.define "shell", primary: true do |shell|
-    shell.vm.box = "picoCTF/shell-base"
+    shell.vm.box = "ubuntu/xenial64"
     shell.vm.network "private_network", ip: "192.168.2.3"
 
     shell.vm.synced_folder ".", "/vagrant", disabled: true
@@ -19,6 +19,7 @@ Vagrant.configure("2") do |config|
 
     shell.vm.provision "shell", path: "vagrant/provision_scripts/install_ansible.sh"
     shell.vm.provision :ansible_local do |ansible|
+      ansible.compatibility_mode = "2.0"
       ansible.playbook = "site.yml"
       ansible.limit = "shell"
       ansible.provisioning_path = "/picoCTF/ansible/"
@@ -32,7 +33,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "web", primary: true do |web|
-    web.vm.box = "picoCTF/web-base"
+    web.vm.box = "ubuntu/xenial64"
     web.vm.network "private_network", ip: "192.168.2.2"
 
     web.vm.synced_folder ".", "/vagrant", disabled: true
@@ -42,6 +43,7 @@ Vagrant.configure("2") do |config|
 
     web.vm.provision "shell", path: "vagrant/provision_scripts/install_ansible.sh"
     web.vm.provision :ansible_local do |ansible|
+      ansible.compatibility_mode = "2.0"
       ansible.playbook = "site.yml"
       ansible.limit = ["db", "web"]
       ansible.provisioning_path = "/picoCTF/ansible/"

--- a/ansible/group_vars/local_development/vars.yml
+++ b/ansible/group_vars/local_development/vars.yml
@@ -35,6 +35,9 @@ shell_manager_deploy_secret: "**insecure-secret**"
 # default insecure "vagrant" password (mkpasswd --method=SHA-512 vagrant)
 shell_admin_password_crypt: "$6$0GcSqMClzx$qEKEiL78VE/Xe0gzuGGuWyUqAlZMObkGnRYwHo4.vSUlvWt6aA7PBH1oGDsOQlykFNScEdEhrirD5oFLOHH011"
 
+# Python Virtualenv settings
+virtualenv_dir: "/picoCTF-env"
+
 ##
 # Database settings (env specific)
 ##

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # Playbook that runs tasks common across all servers
 
+- include: ppas.yml
+  tags:
+   - network
+   - dependency
+
 - include: upgrade.yml
   tags:
     - network
@@ -13,9 +18,9 @@
 
 - include: set_hostname.yml
 
-# Local development environements are the only place the platform should
-# be loaded in directly via filesystem sync without being cloned from a 
-#specific source and branch
+# Local development environments are the only place the platform should
+# be loaded in directly via filesystem sync without being cloned from a
+# specific source and branch
 - include: clone_repo.yml
   when: "'local_development' not in group_names"
   tags:

--- a/ansible/roles/common/tasks/ppas.yml
+++ b/ansible/roles/common/tasks/ppas.yml
@@ -1,0 +1,7 @@
+---
+# Playbook that establishes PPAs for packages in dependencies
+
+# Python3.6
+- apt_repository:
+    repo: ppa:deadsnakes/ppa
+    state: present

--- a/ansible/roles/mongodb/defaults/main.yml
+++ b/ansible/roles/mongodb/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Defaults for the mongodb role. These are the loweset prioirty varaibles
+# Defaults for the mongodb role. These are the lowest priority variables
 # and can easily be overridden in group_vars, host_vars, or command line.
 # Largely these should be sensible defaults and show not require changing.
 
@@ -7,12 +7,12 @@ db_name: picoCTF
 db_data_path: "/data"
 
 # MongoDB User Variables (used in configure_auth.yml task)
-# Passwords should be stored outside version control or in an 
+# Passwords should be stored outside version control or in an
 # ansible-vault protected file.
 initial_admin_name: picoAdmin
 initial_admin_password: "{{ picoAdmin_db_password }}"
 
-# Add additional users an environement specific group_vars file
+# Add additional users an environment specific group_vars file
 mongodb_users: "{{ env_db_users }}"
 
 ###
@@ -23,7 +23,7 @@ mongodb_daemon_name: mongod
 
 mongodb_apt_keyserver: keyserver.ubuntu.com
 mongodb_apt_key_id: EA312927
-mongodb_repo: 'deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.2 main'
+mongodb_repo: 'deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse'
 
 mongodb_conf_auth: true                                               # Run with security
 mongodb_conf_bind_ip: "0.0.0.0"                                       # IP addresses to listen on (Static)

--- a/ansible/roles/mongodb/tasks/configure_auth.yml
+++ b/ansible/roles/mongodb/tasks/configure_auth.yml
@@ -11,8 +11,8 @@
 
 # uses Client Access Control Localhost Exception for first user
 # as described: https://docs.mongodb.org/manual/tutorial/enable-authentication/
-# ignore errors so subsequent runs don't fail due to the lack of 
-# a login_user and login_password 
+# ignore errors so subsequent runs don't fail due to the lack of
+# a login_user and login_password
 - name: Create intital administrative user
   mongodb_user:
     database: admin

--- a/ansible/roles/mongodb/tasks/install.yml
+++ b/ansible/roles/mongodb/tasks/install.yml
@@ -1,7 +1,6 @@
 ---
-# Playbook that installs MongoDB and associted utilities
-# Debian Jessie repositiory verison is only 2.4 so we will install
-# Using mongodb provided configuration for wheezy
+# Playbook that installs MongoDB and associated utilities
+# TODO: Consolidate mongodb tasks into web
 
 - name: Add apt key by id
   apt_key:
@@ -17,25 +16,26 @@
   apt:
     update_cache: yes
 
-# Note different than the debian os package mongodb
-# comming from the repo added above
-- name: Install MongoDB meta package
+- name: Install mongo and python packages
   apt:
-    pkg: mongodb-org
+    name: "{{ item }}"
     state: present
+  with_items:
+    - python3.6       # from PPA
+    - python3.6-dev
+    - python3.6-venv
+    - python-virtualenv
+    - python-pip
+    - mongodb-org     # from PPA
 
-# Nessecary to install more recent verison of pymongo
-- name: Install pip
-  apt:
-    pkg: python-pip
-    state: present
-
-- name: Install pymongo with pip
+- name: Install pymongo in (new) virtualenv
   pip:
     name: pymongo
+    virtualenv: "{{ virtualenv_dir }}"
+    virtualenv_python: python3.6
 
 - name: Ensure mongodb is running
-  service: 
+  service:
     name: "{{ mongodb_daemon_name }}"
     state: started
     enabled: yes

--- a/ansible/roles/pico-shell/files/pam_auth.py
+++ b/ansible/roles/pico-shell/files/pam_auth.py
@@ -88,7 +88,7 @@ def pam_sm_authenticate(pam_handle, flags, argv):
 
     try:
         user = pamh.get_user(None)
-    except pamh.exception, e:
+    except (pamh.exception, e):
         return e.pam_result
 
     try:

--- a/ansible/roles/pico-shell/tasks/dependencies.yml
+++ b/ansible/roles/pico-shell/tasks/dependencies.yml
@@ -10,20 +10,25 @@
 - name: Install picoCTF-shell system dependencies
   apt:
     name: "{{ item }}"
-    state: installed
+    state: present
   with_items:
     - software-properties-common
     - xinetd
     - dpkg
     - dpkg-dev
     - fakeroot
+    - python-virtualenv
     - python-pip      # used for pam module dependencies
     - python3         # used by shell_manager
     - python3-pip     # used for shell_manager dependencies
+    - python3.6       # from PPA, to cover all likely interpreter directives
+    - python3.6-dev
+    - python3.6-venv
     - libffi-dev
     - libssl-dev
     - socat
-    - php5-cli
+    - php7.0-cli      # php5 package deprecated
+    - php7.0-sqlite3
     - gcc-multilib
     - nginx           # used to serve shellinabox and challenge binaries
     - shellinabox
@@ -33,7 +38,7 @@
 - name: Install uwsgi and plugins for shell server
   apt:
     name: "{{ item }}"
-    state: installed
+    state: present
   with_items:
     - uwsgi
     - uwsgi-plugin-php
@@ -44,22 +49,23 @@
 - name: Install pam dependencies
   apt:
     name: "{{ item }}"
-    state: installed
+    state: present
   with_items:
     - libpam-python
     - python-setuptools
 
-# needed for pam module
+# Needed for pam module, no virtualenv
 - name: Install requests
   pip:
     name: requests
 
-- name: Install python packaging
+- name: Install python packaging in (new) virtualenv
   pip:
     name: packaging
-    executable: pip3
+    virtualenv: "{{ virtualenv_dir }}"
+    virtualenv_python: python3.6
 
 - name: Install python appdirs
   pip:
     name: appdirs
-    executable: pip3
+    virtualenv: "{{ virtualenv_dir }}"

--- a/ansible/roles/pico-shell/tasks/deploy_problems.yml
+++ b/ansible/roles/pico-shell/tasks/deploy_problems.yml
@@ -10,7 +10,7 @@
     - "{{ bundle_dir }}"
 
 - name: Package problem sources
-  command: "shell_manager package -o {{ deb_dir }} {{ item }}"
+  command: "{{ virtualenv_dir }}/bin/shell_manager package -o {{ deb_dir }} {{ item }}"
   with_items: "{{ problem_source_dirs }}"
 
 - name: Get a list of deb packages
@@ -23,7 +23,7 @@
   with_items: "{{ deb_files.stdout_lines }}"
 
 - name: Package bundle sources
-  command: "shell_manager bundle -o {{ bundle_dir }} {{ item.source }}"
+  command: "{{ virtualenv_dir }}/bin/shell_manager bundle -o {{ bundle_dir }} {{ item.source }}"
   with_items: "{{ bundles }}"
 
 - name: Get a list of bundle packages
@@ -41,7 +41,7 @@
     force: yes
 
 - name: Deploy Bundles
-  command: "shell_manager deploy -n {{ item.instances }} -b {{item.name}}"
+  command: "{{ virtualenv_dir }}/bin/shell_manager deploy -n {{ item.instances }} -b {{item.name}}"
   with_items: "{{ bundles }}"
 
 - name: Change /tmp permission
@@ -51,7 +51,7 @@
 - name: Change /etc/xinetd.d permission
   become: true
   command: "chmod 750 /etc/xinetd.d"
-  
+
 - name: Change /home/vagrant permission
   command: "chmod 700 /home/vagrant"
   become: true

--- a/ansible/roles/pico-shell/tasks/pam_and_services.yml
+++ b/ansible/roles/pico-shell/tasks/pam_and_services.yml
@@ -3,7 +3,7 @@
 
 # Extracted from picoCTF-platform/scripts/shell_setup.sh
 - name: Template shellinaboxd Service file
-  template: 
+  template:
     src: "shellinaboxd.service.j2"
     dest: "/lib/systemd/system/shellinaboxd.service"
     owner: root
@@ -75,8 +75,9 @@
 - name: Reload sysctl
   command: sysctl --system
 
+# from eth0 to Predictable Interface Name
 - name: Restart networking service to pickup new configs
-  command: bash -c "ifdown eth0 && ifup eth0"
+  command: bash -c "ifdown enp0s3 && ifup enp0s3"
 
 - name: Copy over journald.conf
   copy:
@@ -92,6 +93,6 @@
     state: restarted
 
 - name: Add competitiors group
-  group: 
+  group:
     name: competitors
     state: present

--- a/ansible/roles/pico-shell/tasks/shell_manager.yml
+++ b/ansible/roles/pico-shell/tasks/shell_manager.yml
@@ -1,18 +1,18 @@
 ---
-# Playbook that installs and configures the picoCTF shell_manager from sourrce
+# Playbook that installs and configures the picoCTF shell_manager from source
 
 # Fix "Invalid environment marker: platform_python_implementation != 'PyPy'"
 - name: Upgrade setuptools
   pip:
     name: "setuptools"
-    executable: pip3
+    virtualenv: "{{ virtualenv_dir }}"
     extra_args: "--upgrade"
 
 # Source was cloned in main
 - name: Install picoCTF-shell-manager from source
   pip:
     name: "file://{{ shell_manager_dir }}"
-    executable: pip3
+    virtualenv: "{{ virtualenv_dir }}"
     extra_args: "--upgrade"
 
 - name: Ensure /opt/hacksports directory exists

--- a/ansible/roles/pico-web/tasks/auto_configure.yml
+++ b/ansible/roles/pico-web/tasks/auto_configure.yml
@@ -14,6 +14,9 @@
     {{ shell_proto }}
   environment:
     APP_SETTINGS_FILE: "{{ web_config_dir }}/deploy_settings.py"
+    PATH: "{{ virtualenv_dir }}/bin/"
+  args:
+    executable: "{{ virtualenv_dir }}/bin/python"
   when: auto_add_shell
   no_log: True
 
@@ -21,11 +24,17 @@
   script: scripts/load_problems.py {{ shell_name }}
   environment:
     APP_SETTINGS_FILE: "{{ web_config_dir }}/deploy_settings.py"
+    PATH: "{{ virtualenv_dir }}/bin/"
+  args:
+    executable: "{{ virtualenv_dir }}/bin/python"
   when: auto_load_problems
 
 - name: Auto Start competition
   script: scripts/start_competition.py
   environment:
     APP_SETTINGS_FILE: "{{ web_config_dir }}/deploy_settings.py"
+    PATH: "{{ virtualenv_dir }}/bin/"
+  args:
+    executable: "{{ virtualenv_dir }}/bin/python"
   when: auto_start_competition
 

--- a/ansible/roles/pico-web/tasks/dependencies.yml
+++ b/ansible/roles/pico-web/tasks/dependencies.yml
@@ -10,9 +10,12 @@
 - name: Install picoCTF platform system dependencies
   apt:
     name: "{{ item }}"
-    state: installed
+    state: present
   with_items:
     - python3-pip
+    - python3.6
+    - python3.6-dev
+    - python3.6-venv
     - gunicorn
     - jekyll
     - nginx
@@ -22,9 +25,9 @@
 - name: Install python packaging
   pip:
     name: packaging
-    executable: pip3
+    virtualenv: "{{ virtualenv_dir }}"
 
 - name: Install python appdirs
   pip:
     name: appdirs
-    executable: pip3
+    virtualenv: "{{ virtualenv_dir }}"

--- a/ansible/roles/pico-web/tasks/main.yml
+++ b/ansible/roles/pico-web/tasks/main.yml
@@ -24,7 +24,7 @@
 - include: auto_configure.yml
 
 - name: Ensure nginx is running
-  service: 
+  service:
     name: nginx
     state: started
     enabled: yes

--- a/ansible/roles/pico-web/tasks/picoCTF-webapp.yml
+++ b/ansible/roles/pico-web/tasks/picoCTF-webapp.yml
@@ -12,14 +12,14 @@
 - name: Upgrade setuptools
   pip:
     name: "setuptools"
-    executable: pip3
+    virtualenv: "{{ virtualenv_dir }}"
     extra_args: "--upgrade"
 
 # Source was cloned in main
 - name: Install picoCTF-web api from source
   pip:
     name: "file://{{ pico_web_api_dir }}"
-    executable: pip3
+    virtualenv: "{{ virtualenv_dir }}"
     extra_args: "--upgrade"
 
 - name: Compile CoffeeScript

--- a/ansible/roles/pico-web/templates/ctf-daemon.service.j2
+++ b/ansible/roles/pico-web/templates/ctf-daemon.service.j2
@@ -4,7 +4,8 @@ Description= ctf daemon runner
 [Service]
 Type=simple
 Environment="APP_SETTINGS_FILE={{ web_config_dir }}/deploy_settings.py"
-ExecStart=/usr/local/bin/daemon_manager -d {{ daemon_src_dir }} cache_stats share_instances
+Environment="PATH={{ virtualenv_dir }}"
+ExecStart={{ virtualenv_dir }}/bin/daemon_manager -d {{ daemon_src_dir }} cache_stats share_instances
 RestartSec="5min"
 Restart=always
 

--- a/ansible/roles/pico-web/templates/gunicorn.service.j2
+++ b/ansible/roles/pico-web/templates/gunicorn.service.j2
@@ -5,11 +5,12 @@ After=network.target
 
 [Service]
 Environment="APP_SETTINGS_FILE={{ web_config_dir }}/deploy_settings.py"
+Environment="PATH={{ virtualenv_dir }}"
 PIDFile=/run/gunicorn/pid
 User= {{ gunicorn_user }}
 Group= {{ gunicorn_group }}
 WorkingDirectory= {{ gunicorn_working_dir }}
-ExecStart=/usr/local/bin/gunicorn --pid /run/gunicorn/pid -b {{ gunicorn_listen_on }} -w {{ num_workers }} 'api.app:config_app()'
+ExecStart={{ virtualenv_dir }}/bin/gunicorn --pid /run/gunicorn/pid -b {{ gunicorn_listen_on }} -w {{ num_workers }} 'api.app:config_app()'
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true

--- a/ansible/scripts/add_shell_server.py
+++ b/ansible/scripts/add_shell_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Simple script to programmaticly add a shell server to a running picoCTF web
 # instance.  If using a custom APP_SETTINGS_FILE, ensure the appropriate

--- a/ansible/scripts/load_problems.py
+++ b/ansible/scripts/load_problems.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Simple script to programmaticly load problems from a shell server
 # If using a custom APP_SETTINGS_FILE, ensure the appropriate

--- a/ansible/scripts/start_competition.py
+++ b/ansible/scripts/start_competition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Simple script to programmaticly start a competition useful for development
 # and testing purposes. Defaults to 1 year.

--- a/ansible/site.retry
+++ b/ansible/site.retry
@@ -1,1 +1,0 @@
-dev_shell

--- a/picoCTF-shell/tests/run_tests.sh
+++ b/picoCTF-shell/tests/run_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python3.4 -b -m pytest --showlocals --junitxml /vagrant/shellresults.xml -s -v ./tests
+python3 -b -m pytest --showlocals --junitxml /vagrant/shellresults.xml -s -v ./tests

--- a/picoCTF-web/api/api_manager.py
+++ b/picoCTF-web/api/api_manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Problem management script.
 """

--- a/picoCTF-web/api/daemon_manager.py
+++ b/picoCTF-web/api/daemon_manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import argparse
 import glob
 from importlib.machinery import SourceFileLoader

--- a/picoCTF-web/api/shell_servers.py
+++ b/picoCTF-web/api/shell_servers.py
@@ -92,7 +92,7 @@ def ensure_setup(shell):
     shell_manager is set up correctly.
     """
 
-    result = shell.run(["sudo", "shell_manager", "status"], allow_error=True)
+    result = shell.run(["sudo", "/picoCTF-env/bin/shell_manager", "status"], allow_error=True)
     if result.return_code == 1 and "command not found" in result.stderr_output.decode(
             "utf-8"):
         raise WebException("shell_manager not installed on server.")
@@ -203,7 +203,7 @@ def get_problem_status_from_server(sid):
     shell = get_connection(sid)
     ensure_setup(shell)
 
-    output = shell.run(["sudo", "shell_manager", "status",
+    output = shell.run(["sudo", "/picoCTF-env/bin/shell_manager", "status",
                         "--json"]).output.decode("utf-8")
     data = json.loads(output)
 
@@ -236,7 +236,7 @@ def load_problems_from_server(sid):
 
     shell = get_connection(sid)
 
-    result = shell.run(["sudo", "shell_manager", "publish"])
+    result = shell.run(["sudo", "/picoCTF-env/bin/shell_manager", "publish"])
     data = json.loads(result.output.decode("utf-8"))
 
     # Pass along the server

--- a/picoCTF-web/daemons/cache_stats.py
+++ b/picoCTF-web/daemons/cache_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import time

--- a/picoCTF-web/daemons/share_instances.py
+++ b/picoCTF-web/daemons/share_instances.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import json
 import random

--- a/picoCTF-web/run.py
+++ b/picoCTF-web/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 CTF API Startup script
 """

--- a/picoCTF-web/test/run_tests.sh
+++ b/picoCTF-web/test/run_tests.sh
@@ -4,10 +4,10 @@
 test_path="./unit_tests"
 output_results_prefix="unit"
 
-python3.4 -b -m pytest --showlocals --junitxml /vagrant/${output_results_prefix}results.xml -s -v "$test_path"
+python3 -b -m pytest --showlocals --junitxml /vagrant/${output_results_prefix}results.xml -s -v "$test_path"
 
 
 test_path="./functional_tests"
 output_results_prefix="functional"
 
-python3.4 -b -m pytest --showlocals --junitxml /vagrant/${output_results_prefix}results.xml -s -v "$test_path"
+python3 -b -m pytest --showlocals --junitxml /vagrant/${output_results_prefix}results.xml -s -v "$test_path"

--- a/problems/examples/cryptography/ecb1/ecb.py
+++ b/problems/examples/cryptography/ecb1/ecb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/problems/examples/web-exploitation/sql-injection-1/problem.json
+++ b/problems/examples/web-exploitation/sql-injection-1/problem.json
@@ -1,7 +1,7 @@
 {
   "name": "SQL Injection 1",
   "category": "Web Exploitation",
-  "pkg_dependencies": ["php5-sqlite"],
+  "pkg_dependencies": ["php7.0-sqlite3"],
   "description": "There is a website running at http://{{server}}:{{port}}. Try to see if you can login!",
   "score" : 40,
   "hints": [],

--- a/vagrant/provision_scripts/install_ansible.sh
+++ b/vagrant/provision_scripts/install_ansible.sh
@@ -1,36 +1,13 @@
 #!/bin/bash
 
-# Minimal script to install ansible via pip as described:
-# http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-pip
-
-# Include the following Ansible dependencies
-# sshpass for password based ssh
-# python-passlib for htpasswd module
+# Minimal script to install ansible via apt as described:
+# https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#latest-releases-via-apt-ubuntu
 
 # This will get the base boxes to a place where we can use the Vagrant Ansible Local
 # Provisioner: https://www.vagrantup.com/docs/provisioning/ansible_local.html
 
+# Do not pin ansible version, get latest from PyPy
 
-# We need to use version >2 in order to fix non-executable invetory on windows:
-# ref: https://github.com/ansible/ansible/issues/10068
-# We are currently stuck at 1.9.2 based on a lack of integration for ansible 2.0
-# solution adapted from: https://github.com/mitchellh/vagrant/issues/6793
-
-sudo apt-get update 
-sudo apt-get install -y python-pip build-essential python-dev python-passlib sshpass
-sudo pip install ansible==2.0.2.0
-sudo cp /usr/local/bin/ansible /usr/bin/ansible
-
-
-# In order to use ansible >1.9.2 with vagrant (1.8.1) ansible_local provisioner 
-# we also need to patch ansible-galaxy to correctly detect ansible is installed
-
-# Patch for https://github.com/mitchellh/vagrant/issues/6793 from @MasonM
-# should be removed once vagrant >1.8.1 is released and ansible_local correctly
-# detects ansible being installed.
-# patches https://github.com/mitchellh/vagrant/blob/25ff027b08582978981ed28754a3fed21953a90e/plugins/provisioners/ansible/provisioner/guest.rb#L35-L65
-
-GALAXY='/usr/local/bin/ansible-galaxy'
-FIX="if sys.argv == ['$GALAXY', '--help']: sys.argv.insert(1, 'info')"
-
-[[ ! -f $GALAXY ]] || grep -F -q "$FIX" $GALAXY || sed -i "/__main__/a \\    $FIX" $GALAXY
+sudo apt-add-repository ppa:ansible/ansible
+sudo apt-get update
+sudo apt-get install -y software-properties-common ansible


### PR DESCRIPTION
Rebase from trusty to xenial:
- Update Ansible install to latest via ppa, remove legacy workarounds
- Update ansible-apt state from deprecated "installed" to "present"
- Update PHP5 to 7.0 (problem dependencies should be updated to reflect
  respective sqlite package)
- Add playbook step for PPAs, required for Python3.6 package.
- Python3.6 is installed as apt dependency
- Update commands for "eth0" to Predictable Interface Name
- Set all interpretor directives for python via /usr/bin/env

Wrap all shell/web python code in 3.6 virtualenv:
- Install python-virtualenv package
- Specify virtualenv in all applicable Ansible playbook tasks
- Use virtualenv for python systemd services
- Use virtualenv in web api shell_servers module (NOTE: hardcoded path)